### PR TITLE
Migrate to python cloud client librairies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .secrets
 environment.yaml
-config.yaml
+config.yaml*
 dist
 __pycache__
 *.egg-info

--- a/src/psetup/cli.py
+++ b/src/psetup/cli.py
@@ -24,7 +24,8 @@ def main():
     project_name = root_project.name
     print('DONE')
     print('generating root tag... ', end='')
-    root_tag = tag.generate_root_tag(credentials=credentials, setup=setup)
+    root_tag = tag.generate_root_tag(setup=setup)
+    print('DONE')
     if not root_tag.is_bound(credentials=credentials, project=project_name):
         print('binding root tag... ', end='')
         bound = root_tag.bind(credentials=credentials, project=project_name)

--- a/src/psetup/cli.py
+++ b/src/psetup/cli.py
@@ -24,14 +24,14 @@ def main():
     project_name = root_project.name
     print('DONE')
     print('generating root tag... ', end='')
-    tag.generate_root_tag(setup=setup, project=root_project)
+    tag.generate_root_tag(setup=setup, project=project_name)
     print('DONE')
     print('generating workload identity pool... ', end='')
-    org_pool = workload.generate_provider(
-        credentials=credentials,
+    org_pool = workload.generate_terraform_provider(
         setup=setup,
-        parent=project_name
+        project=project_name
     )
+    print('DONE')
     print('generating service account... ', end='')
     builder_account = service_account.generate_service_account(
         credentials=credentials,

--- a/src/psetup/cli.py
+++ b/src/psetup/cli.py
@@ -24,11 +24,8 @@ def main():
     project_name = root_project.name
     print('DONE')
     print('generating root tag... ', end='')
-    root_tag = tag.generate_root_tag(setup=setup)
+    tag.generate_root_tag(setup=setup, project=root_project)
     print('DONE')
-    if not root_tag.is_bound(credentials=credentials, project=project_name):
-        print('binding root tag... ', end='')
-        bound = root_tag.bind(credentials=credentials, project=project_name)
     print('generating workload identity pool... ', end='')
     org_pool = workload.generate_provider(
         credentials=credentials,
@@ -45,10 +42,10 @@ def main():
     builder_email = builder_account.name.split('/serviceAccounts/')[1]
     print('generating workspace tag... ', end='')
     workspace_tag = tag.generate_workspace_tag(
-        credentials=credentials,
         setup=setup,
         builder_email=builder_email
     )
+    print('DONE')
     print('generating workspace folder... ', end='')
     workspace_folder = folder.generate_folder(
         credentials=credentials,

--- a/src/psetup/cli.py
+++ b/src/psetup/cli.py
@@ -34,11 +34,11 @@ def main():
     print('DONE')
     print('generating service account... ', end='')
     builder_account = service_account.generate_service_account(
-        credentials=credentials,
         setup=setup,
         parent=root_project.project_id,
         poolId=org_pool.name
     )
+    print('DONE')
     builder_email = builder_account.name.split('/serviceAccounts/')[1]
     print('generating workspace tag... ', end='')
     workspace_tag = tag.generate_workspace_tag(
@@ -52,3 +52,4 @@ def main():
         setup=setup,
         builder_email=builder_email
     )
+    print('DONE')

--- a/src/psetup/cli.py
+++ b/src/psetup/cli.py
@@ -20,7 +20,7 @@ def main():
     print(timestamp)
 
     print('generating root project... ', end='')
-    root_project = project.generate_root(credentials=credentials, setup=setup)
+    root_project = project.generate_root(setup=setup)
     project_name = root_project.name
     print('DONE')
     print('generating root tag... ', end='')

--- a/src/psetup/cli.py
+++ b/src/psetup/cli.py
@@ -48,7 +48,6 @@ def main():
     print('DONE')
     print('generating workspace folder... ', end='')
     workspace_folder = folder.generate_folder(
-        credentials=credentials,
         setup=setup,
         builder_email=builder_email
     )

--- a/src/psetup/cli.py
+++ b/src/psetup/cli.py
@@ -38,7 +38,7 @@ def main():
     builder_account = service_account.generate_service_account(
         credentials=credentials,
         setup=setup,
-        parent=root_project.data['projectId'],
+        parent=root_project.project_id,
         poolId=org_pool.name
     )
     builder_email = builder_account.name.split('/serviceAccounts/')[1]

--- a/src/psetup/project.py
+++ b/src/psetup/project.py
@@ -1,62 +1,19 @@
 from random import randint
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
-from psetup.operation import watch
 from google.cloud import resourcemanager_v3
+from google.cloud import service_usage_v1
 from google.iam.v1 import iam_policy_pb2
-
-#from google.cloud import resourcemanager_v3
-#client = resourcemanager_v3.FoldersClient()
-#folder = resourcemanager_v3.Folder()
-#folder.parent = "organizations/66101817749"
-#folder.display_name = "toutoutoutou"
-#request = resourcemanager_v3.CreateFolderRequest(folder=folder)
-#operation = client.create_folder(request=request)
-#response = operation.result()
-#print(response)
-
-class RootProject:
-
-    def __init__(self, setup):
-        self.services = setup['rootProject']['services']
-
-    def enable_services(self, credentials):
-        """
-        Enable a list of services for the project.
-
-        Args:
-            credentials: credential, the user authentification to make a call.
-
-        Returns:
-            dict, the list of services enabled.
-
-        Raises:
-            HttpError, Raises an exception if the API call does not return a
-                successful HTTP response.
-        """
-        with build('serviceusage', 'v1', credentials=credentials) as api:
-            result = []
-            for service in self.services:
-                request = api.services().enable(name='{0}/services/{1}'.format(self.name, service))
-                try:
-                    initial = request.execute()
-                except HttpError as e:
-                    raise e
-                if not ( 'done', True ) in initial.items():
-                    result.append(watch(api=api, operation=initial)['service']['config']['name'])
-                    continue
-                result.append(initial['response']['service']['config']['name'])
-        return None
 
 def create(project):
     """
     Create a project with google API call.
 
     Args:
-        credentials: credential, the user authentification to make a call.
+        project: google.cloud.resourcemanager_v3.types.Project, the project to
+            create.
 
     Returns:
-        dict, the project resulting from the operation.
+        google.cloud.resourcemanager_v3.types.Project, the project created from
+            the operation.
     """
     client = resourcemanager_v3.ProjectsClient()
     request = resourcemanager_v3.CreateProjectRequest(project=project)
@@ -70,123 +27,133 @@ def diff(project):
         existing project.
 
     Args:
-        credentials: credential, the user authentification to make a call.
+        project: google.cloud.resourcemanager_v3.types.Project, the delcared
+            project.
 
     Returns:
-        dict, the difference between declared and existing project, as a
-            dict. If there is no existing state, returns False.
+        google.cloud.resourcemanager_v3.types.Project, the matching project if
+            it exists.
+
+    Raises:
+        ValueError, if there is zero or more than one existing projects
+            matching the labels.
     """
     # this is the query to find the matching projects
     query = [
         'parent={0}'.format(project.parent),
         'AND state=ACTIVE'
     ]
-    client = resourcemanager_v3.ProjectsClient()
     for key, value in project.labels.items():
         query.extend(['AND labels.{0}={1}'.format(key, value)])
-    # build the api for resource management
-    request = resourcemanager_v3.SearchProjectsRequest(query=' '.join(query))
-    page_result = client.search_projects(request=request)
+    query = ' '.join(query)
     projects = []
+
+    # build the client for resource management
+    client = resourcemanager_v3.ProjectsClient()
+    request = resourcemanager_v3.SearchProjectsRequest(query=query)
+
+    page_result = client.search_projects(request=request)
     for project in page_result:
-        projects.extend([ project ])
+        projects.append(project)
+
     num = len(projects)
+
     if num == 0:
-        return None
+        e = ValueError(num)
+        raise e
     if num == 1:
         return projects[0]
     if num > 1:
-        raise RuntimeError('Found {0} projects with labels'.format(num))
+        print('ERROR Too many projects with matching labels.')
+        e = ValueError(num, [ p.name for p in projects ])
+        raise e
 
 def control_access(project, policy):
     """
     Apply IAM policy to the project.
 
     Args:
-        credentials: credential, the user authentification to make a call.
-
-    Returns:
-        dict, the IAM policy applied.
-
-    Raises:
-        HttpError, Raises an exception if the API call does not return a
-            successful HTTP response.
+        project: google.cloud.resourcemanager_v3.types.Project, the delcared
+            project.
+        policy: dict, list all `bindings` to apply to the project policy.
     """
     client = resourcemanager_v3.ProjectsClient()
     request = iam_policy_pb2.SetIamPolicyRequest(
         resource=project.name,
         policy=policy
     )
-    response = client.set_iam_policy(request=request)
-    return response
 
-def enable_services(self, credentials):
+    client.set_iam_policy(request=request)
+
+    return None
+
+def enable_services(project, services):
     """
     Enable a list of services for the project.
 
     Args:
-        credentials: credential, the user authentification to make a call.
-
-    Returns:
-        dict, the list of services enabled.
-
-    Raises:
-        HttpError, Raises an exception if the API call does not return a
-            successful HTTP response.
+        project: google.cloud.resourcemanager_v3.types.Project, the delcared
+            project.
+        services: list, a list of services to enable in the project.
     """
-    with build('serviceusage', 'v1', credentials=credentials) as api:
-        result = []
-        for service in self.services:
-            request = api.services().enable(name='{0}/services/{1}'.format(self.name, service))
-            try:
-                initial = request.execute()
-            except HttpError as e:
-                raise e
-            if not ( 'done', True ) in initial.items():
-                result.append(watch(api=api, operation=initial)['service']['config']['name'])
-                continue
-            result.append(initial['response']['service']['config']['name'])
-    return None
+    client = service_usage_v1.ServiceUsageClient()
+    request = service_usage_v1.BatchEnableServicesRequest(
+        parent=project.name,
+        service_ids=services 
+    )
 
+    operation = client.batch_enable_services(request=request)
+    operation.result()
+
+    return None
 
 def generate_root(setup):
     """
-    Generate the root project and related resources.
+    Generate the root project and related resources. Can either create, update
+        or leave it as it is. The project is also updated with a list of
+        services enabled and a new IAM policy.
 
     Args:
         credentials: credential, the user authentification to make a call.
         setup: dict, the configuration used to build the root structure.
 
     Returns:
-        RootProject, the root project created.
+        google.cloud.resourcemanager_v3.types.Project, the generated project.
     """
+    # Sets the variables for generating the project
+    parent = setup['parent']
     display_name = setup['rootProject']['displayName']
     uuid = str(randint(1,999999))
-    executive_group = setup['google']['groups']['executive_group']
+    project_id = '{0}-{1}'.format(display_name, uuid)
+    exec_gr = 'group:{0}'.format(setup['google']['groups']['executive_group'])
     labels = setup['rootProject']['labels']
-    policy = {
-        'bindings': [
-            {
-                'members': ['group:{0}'.format(executive_group)],
-                'role': 'roles/owner'
-            }
-        ]
-    }
+    services = setup['rootProject']['services']
+    policy = {'bindings': [{'members': [exec_gr], 'role': 'roles/owner'}]}
+
+    # Construct the declared project
     project = resourcemanager_v3.Project(
-        parent=setup['parent'],
-        project_id='{0}-{1}'.format(display_name, uuid),
+        parent=parent,
+        project_id=project_id,
         display_name=display_name,
         labels=labels
     )
-    delta = diff(project)
-    if delta is None:
-        project = create(project=project)
-        print('project created... ', end='')
-    else:
-        project = delta
 
-    # project.enable_services(credentials=credentials)
-    # print('services enabled... ', end='')
+    try:
+        project = diff(project)
+        print('project already exists... ', end='')
+    except ValueError as e:
+        if e.args[0] == 0:
+            project = create(project=project)
+            print('project created... ', end='')
+        else:
+            print('Found {0} projects'.format(e.args[0]))
+            print('List of projects: {0}'.format(str(e.args[1])))
+            raise e
+   
+    enable_services(project=project, services=services)
+    print('services enabled... ', end='')
+
     control_access(project=project, policy=policy)
     print('IAM policy set... ', end='')
+
     return project

--- a/src/psetup/project.py
+++ b/src/psetup/project.py
@@ -114,7 +114,6 @@ def generate_root(setup):
         services enabled and a new IAM policy.
 
     Args:
-        credentials: credential, the user authentification to make a call.
         setup: dict, the configuration used to build the root structure.
 
     Returns:

--- a/src/psetup/service_account.py
+++ b/src/psetup/service_account.py
@@ -1,152 +1,284 @@
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+# base client for all actions on workload identity pools and providers
+client = build('iam', 'v1').projects().serviceAccounts()
+
 class ServiceAccount:
+    """A class to represent a service account in Google Cloud project.
 
-    def __init__(self, setup, parent, poolId):
-        self.accountId = setup['builderAccount']['name']
-        self.name = 'projects/{projectId}/serviceAccounts/{name}@{projectId}.iam.gserviceaccount.com'.format(projectId=parent, name=setup['builderAccount']['name'])
-        self.data = { 
-            'description': setup['builderAccount']['description'],
-            'displayName': setup['builderAccount']['displayName']
-        }
-        self.iam_bindings = {
-            'policy': {
-                'bindings': [
-                    {
-                        'members': [
-                            'group:{0}'.format(setup['google']['groups']['executive_group']),
-                        ],
-                        'role': 'roles/iam.serviceAccountTokenCreator',
-                    },
-                    {
-                        'members': [
-                            'principalSet://iam.googleapis.com/{0}/attribute.terraform_project_id/{1}'.format(poolId, setup['terraform']['workspace_project']),
-                        ],
-                        'role': 'roles/iam.workloadIdentityUser',
-                    },
-                ],
-            },
-        }
-    
-    def create(self, credentials):
-        """
-        Create a service account with google API call.
+    Attributes:
+        id: string, the ID for the service account, which becomes the final
+            component of the resource name.
+        description: string, a description of the service account.
+        display_name: string, a user-friendly name for the service account.
+        project: string, the ID of the project to create this account in.
+
+    """
+
+    def __init__(self,
+        id=None,
+        project=None,
+        display_name=None,
+        description=None
+    ):
+        """Initializes the instance based on attributes.
 
         Args:
-            credentials: credentials, the user authentification to make a call.
-
-        Returns:
-            dict, the service account resulting from the operation.
-
-        Raises:
-            HttpError, Raises an exception if the API call does not return a
-                successful HTTP response.
+            id: string, the ID for the service account, which becomes the final
+                component of the resource name.
+            project: string, the ID of the project to create this account in.
+            display_name: string, a user-friendly name for the service account.
+            description: string, a description of the service account.
         """
-        # build the api for resource management
-        body = {
-            'accountId': self.accountId,
-            'serviceAccount': self.data
+        self.id = id
+        self.project = project
+        self.description = description
+        self.display_name = display_name
+
+    def update_from_dict(self, body):
+        """Update the instance from a dictionnary.
+
+        Args:
+            body: dict, the key-value representation of all or any part of the
+                instance attributes.
+        """
+        try:
+            self.id = body['name'].split('/serviceAccounts/')[-1].split('@')[0]
+        except KeyError:
+            pass
+        try:
+            self.project = body['name'].split('/serviceAccounts/')[0].split('/')[-1]
+        except KeyError:
+            pass
+        try:
+            self.description = body['description']
+        except KeyError:
+            pass
+        try:
+            self.display_name = body['display_name']
+        except KeyError:
+            pass
+
+    @property
+    def name(self):
+        """Returns the fully qualified name of the instance.
+        """
+        fmt = 'projects/{projectId}/serviceAccounts/{name}@{projectId}.iam.gserviceaccount.com'.format(projectId=self.project, name=self.id)
+        return fmt
+    
+def _create_sa(sa):
+    """
+    Create a service account according to a declared one.
+
+    Args:
+        sa: ServiceAccount, the delcared service account.
+
+    Returns:
+        ServiceAccount, the service account created from the
+            operation.
+    """
+    # build the create request body
+    body = {
+        'accountId': sa.id,
+        'serviceAccount': {
+            'description': sa.description,
+            'displayName': sa.display_name
         }
-        with build('iam', 'v1', credentials=credentials).projects().serviceAccounts() as api:
-            request = api.create(name=self.name.split('/serviceAccounts/')[0], body=body)
-            try:
-                service_account = request.execute()
-            except HttpError as e:
-                raise e
-        return service_account
+    }
+
+    existing_sa = ServiceAccount(
+        name=sa.name
+    )
+
+    with client as api:
+        request = api.create(
+            name='projects/{0}'.format(sa.project),
+            body=body,
+        )
+
+        result = request.execute()
+
+    existing_sa.update_from_dict(result)
+
+    print('service account created... ', end='')
+
+    return existing_sa
+
+def _update_sa(declared_sa, existing_sa):
+    """
+    Update an existing service account compared to a declared one.
+
+    Args:
+        declared_sa: ServiceAccount, the declared service account.
+        existing_sa: ServiceAccount, the existing service account.
+
+    Returns:
+        ServiceAccount, the service account updated from the operation.
+    """
+    mask = _diff(declared=declared_sa, existing=existing_sa)
+    # build the update request body
+    body = {
+        'serviceAccount': {
+            'description': declared_sa.description,
+            'displayName': declared_sa.display_name
+        },
+        'updateMask': ','.join(mask)
+    }
+
+    # If there is non differences, return the original existing key.
+    if mask == []:
+        return existing_sa
     
-    def update(self, credentials, mask):
-        """
-        Update a service account with google API call.
+    with client as api:
+        request = api.patch(
+            name=declared_sa.name,
+            body=body
+        )
 
-        Args:
-            credentials: credential, the user authentification to make a call.
-            mask: string, a comma-separated list of fields to update.
+        result = request.execute()
 
-        Returns:
-            dict, the service account resulting from the operation.
-        
-        Raises:
-            HttpError, Raises an exception if the API call does not return a
-                successful HTTP response.
-        """
-        # build the api for resource management
-        body = {
-            'serviceAccount': self.data,
-            'updateMask': mask
-        }
-        with build('iam', 'v1', credentials=credentials).projects().serviceAccounts() as api:
-            request = api.patch(name=self.name, body=body)
-            try:
-                service_account = request.execute()
-            except HttpError as e:
-                raise e
-        return service_account
+    existing_sa.update_from_dict(result)
+
+    print('service account updated... ', end='')
+
+    return existing_sa
+
+def _diff(declared, existing):
+    """
+    Show the differences between a declared and an existing service account.
+
+    Args:
+        declared: ServiceAccount, the declared service account.
+        existing: ServiceAccount, the existing service account.
+
+    Returns:
+        list, the list of attributes to update to match existing and declared.
+    """
+    mask = []
+
+    for attr in existing.__dict__.keys():
+        if existing.__getattribute__(attr) != declared.__getattribute__(attr):
+            mask.append(attr)
     
-    def diff(self, credentials):
-        """
-        Show the differences between the declared service account and
-            corresponding existing one.
+    return mask
 
-        Args:
-            credentials: credential, the user authentification to make a call.
+def _get_sa(sa):
+    """
+    Get the existing service account in project corresponding to the
+        declared service account.
 
-        Returns:
-            dict, the difference between declared and existing service account,
-                as a dict. If there is no existing state, returns None.
+    Args:
+        pool: ServiceAccount, the delcared service account.
 
-        Raises:
-            HttpError, Raises an exception if the API call does not return a
-                successful HTTP response.
-        """
-        # build the api for resource management
-        with build('iam', 'v1', credentials=credentials).projects().serviceAccounts() as api:
-            request = api.get(name=self.name)
-            try:
-                service_account = request.execute()
-            except HttpError as e:
-                if e.status_code == 404:
-                    return None
-                raise e
-        diff = {}
-        if service_account['description'] != self.data['description']:
-            diff['description'] = self.data['description']
-        if service_account['displayName'] != self.data['displayName']:
-            diff['displayName'] = self.data['displayName']
-        return diff
+    Returns:
+        ServiceAccount, the existing service account.
+
+    Raises:
+        ValueError, if there is no service account matching the
+            definition.
+    """
+    parent = 'projects/{0}'.format(sa.project)
+    existing = None
+
+    existing_sa = ServiceAccount(
+        id=sa.id,
+        project=sa.project
+    )
+
+    with client as api:
+        request = api.list(name=parent)
+
+        while request is not None:
+            results = request.execute()
+            
+            for result in results['accounts']:
+                if result['name'] == sa.name:
+                    existing = result
+
+            request = api.list_next(request, results)
     
-    def access_control(self, credentials):
-        """
-        Apply IAM policy to the service account.
+    if existing is None:
+        raise ValueError(0)
+    
+    existing_sa.update_from_dict(existing)
 
-        Args:
-            credentials: credential, the user authentification to make a call.
+    return existing_sa
 
-        Returns:
-            dict, the IAM policy applied.
+    
+def access_control(self, credentials):
+    """
+    Apply IAM policy to the service account.
 
-        Raises:
-            HttpError, Raises an exception if the API call does not return a
-                successful HTTP response.
-        """
-        with build('iam', 'v1', credentials=credentials).projects().serviceAccounts() as api:
-            request = api.setIamPolicy(resource=self.name, body=self.iam_bindings)
-            try:
-                result = request.execute()
-            except HttpError as e:
-                raise e
-        return None
+    Args:
+        credentials: credential, the user authentification to make a call.
 
-def generate_service_account(credentials, setup, parent, poolId):
-    service_account = ServiceAccount(setup=setup, parent=parent, poolId=poolId)
-    diff = service_account.diff(credentials=credentials)
-    if diff is None:
-        service_account.create(credentials=credentials)
-        print('service account created... ', end='')
-    elif diff != {}:
-        service_account.update(credentials=credentials, mask=','.join(diff.keys()))
-        print('service account updated... ', end='')
-    service_account.access_control(credentials=credentials)
-    print('service_account is up-to-date.')
-    return service_account
+    Returns:
+        dict, the IAM policy applied.
+
+    Raises:
+        HttpError, Raises an exception if the API call does not return a
+            successful HTTP response.
+    """
+    with build('iam', 'v1', credentials=credentials).projects().serviceAccounts() as api:
+        request = api.setIamPolicy(resource=self.name, body=self.iam_bindings)
+        try:
+            result = request.execute()
+        except HttpError as e:
+            raise e
+    return None
+
+def generate_service_account(setup, parent, poolId):
+    """Generate the builder servie account for the root structure.
+    
+    Can either create, update or leave it as it is.
+
+    Args:
+        setup: dict, the configuration used to build the root structure.
+        parent: string, the ID of the project hosting the service account.
+        poolId: string, the name of the workload identity pool that can
+            delegate access to the service account.
+
+    Returns:
+        ServiceAccount, the generated service account.
+    """
+    id = setup['builderAccount']['name']
+    policy = {
+        'policy': {
+            'bindings': [
+                {
+                    'members': [
+                        'group:{0}'.format(setup['google']['groups']['executive_group']),
+                    ],
+                    'role': 'roles/iam.serviceAccountTokenCreator',
+                },
+                {
+                    'members': [
+                        'principalSet://iam.googleapis.com/{0}/attribute.terraform_project_id/{1}'.format(poolId, setup['terraform']['workspace_project']),
+                    ],
+                    'role': 'roles/iam.workloadIdentityUser',
+                },
+            ],
+        },
+    }
+
+    declared_sa = ServiceAccount(
+        id=id,
+        project=parent,
+        display_name=setup['builderAccount']['displayName'],
+        description=setup['builderAccount']['description']
+    )
+
+    try:
+        sa = _get_sa(declared_sa)
+    except ValueError as e:
+        if e.args[0] == 0:
+            sa = _create_sa(declared_sa)
+        else:
+            raise e
+
+    sa = _update_sa(declared_sa, sa)
+
+    #service_account.access_control(credentials=credentials)
+
+    return sa

--- a/src/psetup/tag.py
+++ b/src/psetup/tag.py
@@ -278,11 +278,12 @@ def generate_root_tag(setup, project):
 
     Args:
         setup: dict, the configuration used to build the root structure.
+        project: string, the name of the project to bind the tag value with.
 
     Returns:
         google.cloud.resourcemanager_v3.types.TagValue, the generated tag value.
     """
-    fqn = '//cloudresourcemanager.googleapis.com/{0}'.format(project.name)
+    fqn = '//cloudresourcemanager.googleapis.com/{0}'.format(project)
 
     declared_key = resourcemanager_v3.TagKey(
         parent=setup['parent'],

--- a/src/psetup/tag.py
+++ b/src/psetup/tag.py
@@ -339,6 +339,7 @@ def generate_workspace_tag(setup, builder_email):
 
     Args:
         setup: dict, the configuration used to build the root structure.
+        builder_email: string, the email of the builder service account.
 
     Returns:
         google.cloud.resourcemanager_v3.types.TagKey, the generated tag value.

--- a/src/psetup/tag.py
+++ b/src/psetup/tag.py
@@ -1,14 +1,9 @@
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from psetup import operation
-
-root_tag_key_description = '''Use this tag to target a project that will be
-used as a root project for the organization. Definition of a root project can
-be found at https://github.com/RaphaeldeGail/prolegomenous-setup'''
-
-true_tag_value_description = '''This value indicates that the project is a root
-of the organization. It should be only used for project resources and should be
-unique among an organization.'''
+from google.cloud import resourcemanager_v3
+from google.iam.v1 import iam_policy_pb2
+from google.protobuf import field_mask_pb2
 
 class TagKey:
 
@@ -125,15 +120,6 @@ class TagKey:
             except HttpError as e:
                 raise e
         return None
-
-class RootTagKey(TagKey):
-
-    def __init__(self, setup):
-        super().__init__(
-            parent=setup['parent'],
-            description=setup['rootTag']['description'],
-            short_name=setup['rootTag']['shortName']
-        )
 
 class WorkspaceTagKey(TagKey):
 
@@ -303,25 +289,223 @@ class RootTagValue:
             return True
         return False
 
-def generate_root_tag(credentials, setup):
-    root_key = RootTagKey(setup=setup)
-    diff = root_key.diff(credentials=credentials)
-    if diff is None:
-        root_key.create(credentials=credentials)
-        print('tag key created... ', end='')
-    elif diff != {}:
-        root_key.update(credentials=credentials)
-        print('tag key updated... ', end='')
-    true_value = RootTagValue(setup=setup, parent=root_key.name, namespace=root_key.namespace)
-    diff = true_value.diff(credentials=credentials)
-    if diff is None:
-        true_value.create(credentials=credentials)
-        print('tag value created... ', end='')
-    elif diff != {}:
-        true_value.update(credentials=credentials)
-        print('tag value updated... ', end='')
-    print('tag value is up-to-date.')
-    return true_value
+def create(key):
+    """
+    Create a tag key with google API call.
+
+    Args:
+        key: google.cloud.resourcemanager_v3.types.TagKey, the delcared tag key.
+
+    Returns:
+        google.cloud.resourcemanager_v3.types.TagKey, the tag key created from
+            the operation.
+    """
+    client = resourcemanager_v3.TagKeysClient()
+    request = resourcemanager_v3.CreateTagKeyRequest(tag_key=key)
+    operation = client.create_tag_key(request=request)
+    response = operation.result()
+    print('key created... ', end='')
+    return response
+
+def update(key, mask):
+    """
+    Update a tag key with google API call.
+
+    Args:
+        key: google.cloud.resourcemanager_v3.types.TagKey, the delcared tag key.
+        mask: string, a mask of entries to update to match the delcared tag key.
+
+    Returns:
+        google.cloud.resourcemanager_v3.types.TagKey, the tag key updated from
+            the operation.
+    """
+    client = resourcemanager_v3.TagKeysClient()
+    update_mask = field_mask_pb2.FieldMask(paths=mask)
+    request = resourcemanager_v3.UpdateTagKeyRequest(
+        tag_key=key,
+        update_mask=update_mask
+    )
+    
+    operation = client.update_tag_key(request=request)
+    response = operation.result()
+    print('key updated... ', end='')
+    return response
+
+def get(key):
+    """
+    Get the existing tag in Google organization corresponding to the definition.
+
+    Args:
+        key: google.cloud.resourcemanager_v3.types.TagKey, the delcared tag key.
+
+    Returns:
+        google.cloud.resourcemanager_v3.types.TagKey, the existing tag key.
+
+    Raises:
+        ValueError, if there is no tag key matching the definition.
+    """
+    # this is the query to find the matching projects
+    parent = key.parent
+    existing = None
+
+    # build the client for resource management
+    client = resourcemanager_v3.TagKeysClient()
+    request = resourcemanager_v3.ListTagKeysRequest(parent=parent)
+
+    page_result = client.list_tag_keys(request=request)
+    for result in page_result:
+        if result.short_name == key.short_name:
+            existing = result
+    
+    if existing is None:
+        raise ValueError(0)
+    
+    return existing
+
+def diff(declared, existing):
+    """
+    Get the existing tag in Google organization corresponding to the definition.
+
+    Args:
+        declared: [google.cloud.resourcemanager_v3.types.TagKey,
+            google.cloud.resourcemanager_v3.types.TagValue] the delcared tag
+            key or value.
+        existing: [google.cloud.resourcemanager_v3.types.TagKey,
+            google.cloud.resourcemanager_v3.types.TagValue] the existing tag
+            key or value.
+
+    Returns:
+        list, the list of attributes to update to match existing and declared.
+    """
+    if existing.description == declared.description:
+        return []
+    
+    return ['description']
+
+def create_value(value):
+    """
+    Create a tag value with google API call.
+
+    Args:
+        key: google.cloud.resourcemanager_v3.types.TagValue, the delcared tag
+            value.
+
+    Returns:
+        google.cloud.resourcemanager_v3.types.TagValue, the tag value created
+            from the operation.
+    """
+    client = resourcemanager_v3.TagValuesClient()
+    request = resourcemanager_v3.CreateTagValueRequest(tag_value=value)
+    operation = client.create_tag_value(request=request)
+    response = operation.result()
+    print('value created... ', end='')
+    return response
+
+def update_value(value, mask):
+    """
+    Update a tag value with google API call.
+
+    Args:
+        value: google.cloud.resourcemanager_v3.types.TagValue, the delcared tag
+            value.
+        mask: list, a mask of entries to update to match the delcared tag value.
+
+    Returns:
+        google.cloud.resourcemanager_v3.types.TagValue, the tag value updated
+            from the operation.
+    """
+    client = resourcemanager_v3.TagValuesClient()
+    update_mask = field_mask_pb2.FieldMask(paths=mask)
+    request = resourcemanager_v3.UpdateTagValueRequest(
+        tag_value=value,
+        update_mask=update_mask
+    )
+    
+    operation = client.update_tag_value(request=request)
+    response = operation.result()
+    print('value updated... ', end='')
+    return response
+
+def get_value(value):
+    """
+    Get the existing tag value in Google organization corresponding to the
+        definition.
+
+    Args:
+        value: google.cloud.resourcemanager_v3.types.TagValue, the delcared tag
+            value.
+
+    Returns:
+        google.cloud.resourcemanager_v3.types.TagValue, the existing tag value.
+
+    Raises:
+        ValueError, if there is no tag value matching the definition.
+    """
+    # this is the query to find the matching projects
+    parent = value.parent
+    existing = None
+
+    # build the client for resource management
+    client = resourcemanager_v3.TagValuesClient()
+    request = resourcemanager_v3.ListTagValuesRequest(parent=parent)
+
+    page_result = client.list_tag_values(request=request)
+    for result in page_result:
+        if result.short_name == value.short_name:
+            existing = result
+    
+    if existing is None:
+        raise ValueError(0)
+    
+    return existing
+
+def generate_root_tag(setup):
+    """
+    Generate the root tag key and value. Can either create, update or leave it
+        as it is. The tag is also updated with a new IAM policy.
+
+    Args:
+        setup: dict, the configuration used to build the root structure.
+
+    Returns:
+        google.cloud.resourcemanager_v3.types.TagValue, the generated tag value.
+    """
+    # Sets the variables for generating the tag
+    declared_key = resourcemanager_v3.TagKey(
+        parent=setup['parent'],
+        short_name=setup['rootTag']['shortName'],
+        description=setup['rootTag']['description'],
+    )
+    declared_value = resourcemanager_v3.TagValue(
+        short_name=setup['trueValue']['shortName'],
+        description=setup['trueValue']['description'],
+    )
+
+    try:
+        key = get(declared_key)
+    except ValueError as e:
+        if e.args[0] == 0:
+            key = create(declared_key)
+    mask = diff(declared=declared_key, existing=key)
+    if mask == []:
+        print('key already exists... ', end='')
+    else:
+        key = update(declared_key, mask)
+
+    declared_value.parent = key.name
+
+    try:
+        value = get_value(declared_value)
+    except ValueError as e:
+        if e.args[0] == 0:
+            value = create_value(value)
+    mask = diff(declared=declared_value, existing=value)
+    if mask == []:
+        print('value already exists... ', end='')
+    else:
+        value = update_value(declared_value, mask)    
+
+    return value
 
 def generate_workspace_tag(credentials, setup, builder_email):
     workspace_key = WorkspaceTagKey(setup=setup, builder_email=builder_email)


### PR DESCRIPTION
The psetup pacakge now relies on python Cloud client librairies for API calls, with exception of google-iam-v1 which is only available through the generic python client.